### PR TITLE
Update Plugins with Structure Info

### DIFF
--- a/game_MUA1.py
+++ b/game_MUA1.py
@@ -7,12 +7,48 @@ except:
 
 import mobase
 from ..basic_game import BasicGame
-from ..basic_features import BasicGameSaveGameInfo
+
+class MUA1ModDataChecker(mobase.ModDataChecker):
+    def __init__(self):
+        super().__init__()
+        self.validDirNames = [
+            "actors",
+            "automaps",
+            "conversations",
+            "data",
+            "dialogs",
+            "effects",
+            "hud",
+            "maps",
+            "models",
+            "motionpaths",
+            "movies",
+            "packages",
+            "plugins",
+            "scripts",
+            "shaders",
+            "skybox",
+            "sounds",
+            "subtitles",
+            "texs",
+            "textures",
+            "ui"
+        ]
+
+    def dataLooksValid(
+        self, tree: mobase.IFileTree
+    ) -> mobase.ModDataChecker.CheckReturn:
+        for entry in tree:
+            if not entry.isDir():
+                continue
+            if entry.name().casefold() in self.validDirNames:
+                return mobase.ModDataChecker.VALID
+        return mobase.ModDataChecker.INVALID
 
 class MarvelUltimateAllianceGame(BasicGame):
     Name = "Marvel - Ultimate Alliance Support Plugin"
     Author = "MrKablamm0fish, ak2yny, Rampage, and BaconWizard17"
-    Version = "2.0.0"
+    Version = "2.0.1"
 
     GameName = "Marvel - Ultimate Alliance"
     GameShortName = "mua1"
@@ -20,10 +56,16 @@ class MarvelUltimateAllianceGame(BasicGame):
     GameNexusId = 000
     GameSteamId = 000000
     GameBinary = "game.exe"
+    GameLauncher = "MUA.exe"
     GameDataPath = ""
     GameSaveExtension = "save"
     GameDocumentsDirectory = "%DOCUMENTS%/Activision/Marvel Ultimate Alliance"
     GameSavesDirectory = "%GAME_DOCUMENTS%/Save"
+
+    def init(self, organizer: mobase.IOrganizer) -> bool:
+        super().init(organizer)
+        self._featureMap[mobase.ModDataChecker] = MUA1ModDataChecker()
+        return True
 
     def executables(self):
         return [

--- a/game_MUA1_Steam.py
+++ b/game_MUA1_Steam.py
@@ -7,12 +7,51 @@ except:
 
 import mobase
 from ..basic_game import BasicGame
-from ..basic_features import BasicGameSaveGameInfo
+
+class MUA1ModDataChecker(mobase.ModDataChecker):
+    def __init__(self):
+        super().__init__()
+        self.validDirNames = [
+            "actors",
+            "automaps",
+            "conversations",
+            "cursors",
+            "data",
+            "dialogs",
+            "effects",
+            "eula",
+            "hud",
+            "maps",
+            "models",
+            "motionpaths",
+            "movies",
+            "packages",
+            "plugins",
+            "SavesDir",
+            "scripts",
+            "Settings",
+            "shaders",
+            "skybox",
+            "sounds",
+            "subtitles",
+            "textures",
+            "ui"
+        ]
+
+    def dataLooksValid(
+        self, tree: mobase.IFileTree
+    ) -> mobase.ModDataChecker.CheckReturn:
+        for entry in tree:
+            if not entry.isDir():
+                continue
+            if entry.name().casefold() in self.validDirNames:
+                return mobase.ModDataChecker.VALID
+        return mobase.ModDataChecker.INVALID
 
 class MarvelUltimateAllianceGame(BasicGame):
     Name = "Marvel - Ultimate Alliance (Steam Version) Support Plugin"
     Author = "MrKablamm0fish, ak2yny, Rampage, and BaconWizard17"
-    Version = "2.0.0"
+    Version = "2.0.1"
 
     GameName = "Marvel - Ultimate Alliance (Steam)"
     GameShortName = "mua1s"
@@ -21,6 +60,14 @@ class MarvelUltimateAllianceGame(BasicGame):
     GameSteamId = 433300
     GameBinary = "marvel.exe"
     GameDataPath = ""
+    GameSaveExtension = "sav"
+    GameDocumentsDirectory = "%USERPROFILE%/AppData/Roaming/Activision/Marvel Ultimate Alliance"
+    GameSavesDirectory = "%GAME_PATH%/SavesDir"
+
+    def init(self, organizer: mobase.IOrganizer) -> bool:
+        super().init(organizer)
+        self._featureMap[mobase.ModDataChecker] = MUA1ModDataChecker()
+        return True
 
     def executables(self):
         return [
@@ -29,4 +76,3 @@ class MarvelUltimateAllianceGame(BasicGame):
                 QFileInfo(self.gameDirectory(), "Marvel.exe"),
             ),
         ]
-

--- a/game_MUA2.py
+++ b/game_MUA2.py
@@ -7,12 +7,11 @@ except:
 
 import mobase
 from ..basic_game import BasicGame
-from ..basic_features import BasicGameSaveGameInfo
 
 class MarvelUltimateAllianceGame(BasicGame):
     Name = "Marvel - Ultimate Alliance 2 Support Plugin"
     Author = "MrKablamm0fish, ak2yny, Rampage, and BaconWizard17"
-    Version = "2.0.0"
+    Version = "2.0.1"
 
     GameName = "Marvel - Ultimate Alliance 2"
     GameShortName = "mua2"
@@ -21,6 +20,8 @@ class MarvelUltimateAllianceGame(BasicGame):
     GameSteamId = 433320
     GameBinary = "alliance.exe"
     GameDataPath = ""
+    GameSaveExtension = "sav"
+    GameSavesDirectory = "%GAME_PATH%/SavesDir"
 
     def executables(self):
         return [

--- a/game_XML2.py
+++ b/game_XML2.py
@@ -7,12 +7,47 @@ except:
 
 import mobase
 from ..basic_game import BasicGame
-from ..basic_features import BasicGameSaveGameInfo
+
+class XML2ModDataChecker(mobase.ModDataChecker):
+    def __init__(self):
+        super().__init__()
+        self.validDirNames = [
+            "Actors",
+            "Automaps",
+            "Conversations",
+            "Data",
+            "Dialogs",
+            "Effects",
+            "HUD",
+            "Maps",
+            "Models",
+            "MotionPaths",
+            "Movies",
+            "Packages",
+            "plugins",
+            "Scripts",
+            "Skybox",
+            "Sounds",
+            "Subtitles",
+            "Texs",
+            "Textures",
+            "UI"
+        ]
+
+    def dataLooksValid(
+        self, tree: mobase.IFileTree
+    ) -> mobase.ModDataChecker.CheckReturn:
+        for entry in tree:
+            if not entry.isDir():
+                continue
+            if entry.name().casefold() in self.validDirNames:
+                return mobase.ModDataChecker.VALID
+        return mobase.ModDataChecker.INVALID
 
 class XMenLegendsIIGame(BasicGame):
     Name = "X-Men Legends II Support Plugin"
     Author = "UltraMegaMagnus, ak2yny, Rampage, and BaconWizard17"
-    Version = "2.0.0"
+    Version = "2.0.1"
 
     GameName = "X-Men Legends II - Rise of Apocalypse"
     GameShortName = "xml2"
@@ -25,6 +60,11 @@ class XMenLegendsIIGame(BasicGame):
     GameDocumentsDirectory = "%DOCUMENTS%/Activision/X-Men Legends 2"
     GameSavesDirectory = "%GAME_DOCUMENTS%/Save"
 
+    def init(self, organizer: mobase.IOrganizer) -> bool:
+        super().init(organizer)
+        self._featureMap[mobase.ModDataChecker] = XML2ModDataChecker()
+        return True
+
     def executables(self):
         return [
             mobase.ExecutableInfo(
@@ -32,4 +72,3 @@ class XMenLegendsIIGame(BasicGame):
                 QFileInfo(self.gameDirectory(), "xmen2.exe"),
             ),
         ]
-


### PR DESCRIPTION
Adding structure information (game folders) enables automatic detection of the main folder and simplifies installation. It also shows if a mod has folders that the game doesn't support. It unfortunately also marks mods as such, if they don't have any folders and only modify files in the main directory, but I don't think that's a problem.